### PR TITLE
Add Folia support and enhance version handling

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -248,16 +248,6 @@ jobs:
             2. Place it in your server's `plugins` folder
             3. Restart your server
             
-            ### 📋 Requirements
-            - **Minecraft Server**: 1.20.1+
-            - **Java**: 17+
-            - **Server Software**: Paper, Spigot, or compatible
-            
-            ### 🔗 Links
-            - **Documentation**: [Wiki](https://github.com/${{ github.repository }}/wiki)
-            - **Support**: [Issues](https://github.com/${{ github.repository }}/issues)
-            - **Source Code**: [Repository](https://github.com/${{ github.repository }})
-            
             **Full Changelog**: https://github.com/${{ github.repository }}/compare/${{ steps.get-previous-tag.outputs.previous-tag }}...v${{ steps.find-jar.outputs.version }}
           files: |
             ${{ steps.find-jar.outputs.jar-file }}

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ _☁️ A high-performance Minecraft server plugin for paper-based servers built
     - Available: English, German
     - Planned: French, Spanish, Portuguese, Polish, Russian, Chinese and more!
 * 📋 **Highly Configurable:** Through config, language files and more
-* 🎮 **Newest-Platform:** Works on Paper-based servers (1.20+)
+* 🎮 **Platform Support:** Works on Paper and Folia servers (1.20+)
 * ☕ **Performance-Focused:** Fully written in Async Kotlin for high performance
 * 🛡️ **Modern Standards:** Security, stability, and best practices
 * 🔗 **Online Dashboard:** Web interface to manage your server
@@ -26,7 +26,7 @@ _☁️ A high-performance Minecraft server plugin for paper-based servers built
 
 ## 📋 Requirements
 
-* 📄 Paper-based server (Version 1.20 or higher - PaperMC, Purpur, Pufferfish, CanvasMC etc.)
+* 📄 Paper-based server or Folia (Version 1.20 or higher - PaperMC, Purpur, Pufferfish, CanvasMC, Folia etc.)
 * ☕ Java 17 or higher (Java 21 recommended)
 
 ### 🔍 Code Quality & Security
@@ -40,6 +40,7 @@ _☁️ A high-performance Minecraft server plugin for paper-based servers built
 ### 📁 Codebase Structure
 * **Platform Support:**
   * Paper/Bukkit server implementation
+  * Folia multi-threaded server support
 * **Template System:** Build-time constant generation
 * **Plugin Configuration:** YAML-based configuration
 

--- a/app/src/main/kotlin/de/cloudly/CloudlyPaper.kt
+++ b/app/src/main/kotlin/de/cloudly/CloudlyPaper.kt
@@ -3,6 +3,7 @@ package de.cloudly
 import de.cloudly.config.ConfigManager
 import de.cloudly.config.LanguageManager
 import de.cloudly.radar.ReleaseRadar
+import de.cloudly.utils.SchedulerUtils
 import org.bukkit.plugin.java.JavaPlugin
 
 class CloudlyPaper : JavaPlugin() {
@@ -37,6 +38,10 @@ class CloudlyPaper : JavaPlugin() {
         
         // Log plugin information using translations
         logger.info(languageManager.getMessage("plugin.enabled", "version" to description.version))
+        
+        // Log server type detection
+        val serverType = if (SchedulerUtils.isFolia()) "Folia" else "Paper/Spigot"
+        logger.info("Detected server type: $serverType")
         
         // Log configuration status
         val debugMode = configManager.getBoolean("plugin.debug", false)

--- a/app/src/main/kotlin/de/cloudly/radar/GitHubRelease.kt
+++ b/app/src/main/kotlin/de/cloudly/radar/GitHubRelease.kt
@@ -37,8 +37,100 @@ data class GitHubRelease(
 
     /**
      * Check if this release is newer than another release.
+     * First compares versions semantically, then falls back to publication date.
      */
     fun isNewerThan(other: GitHubRelease?): Boolean {
-        return other == null || this.publishedAt.isAfter(other.publishedAt)
+        if (other == null) return true
+        
+        // Compare versions semantically first
+        val thisVersion = normalizeVersion(this.tagName)
+        val otherVersion = normalizeVersion(other.tagName)
+        
+        val versionComparison = compareVersions(thisVersion, otherVersion)
+        
+        // If versions are the same, compare by publication date
+        return if (versionComparison == 0) {
+            this.publishedAt.isAfter(other.publishedAt)
+        } else {
+            versionComparison > 0
+        }
+    }
+    
+    /**
+     * Check if this release matches the current plugin version.
+     */
+    fun matchesVersion(pluginVersion: String): Boolean {
+        val releaseVersion = normalizeVersion(this.tagName)
+        val currentVersion = normalizeVersion(pluginVersion)
+        return releaseVersion == currentVersion
+    }
+    
+    /**
+     * Normalize a version string by removing 'v' prefix and handling common formats.
+     */
+    private fun normalizeVersion(version: String): String {
+        return version.removePrefix("v").lowercase()
+    }
+    
+    /**
+     * Compare two semantic version strings.
+     * Returns: > 0 if version1 > version2, < 0 if version1 < version2, 0 if equal
+     */
+    private fun compareVersions(version1: String, version2: String): Int {
+        val parts1 = parseVersionParts(version1)
+        val parts2 = parseVersionParts(version2)
+        
+        // Compare major, minor, patch
+        for (i in 0 until minOf(parts1.size, parts2.size, 3)) {
+            val compare = parts1[i].compareTo(parts2[i])
+            if (compare != 0) return compare
+        }
+        
+        // Handle pre-release identifiers (alpha, beta, rc)
+        val preRelease1 = extractPreReleaseInfo(version1)
+        val preRelease2 = extractPreReleaseInfo(version2)
+        
+        return when {
+            preRelease1 == null && preRelease2 == null -> 0
+            preRelease1 == null -> 1 // Release > pre-release
+            preRelease2 == null -> -1 // Pre-release < release
+            else -> comparePreReleases(preRelease1, preRelease2)
+        }
+    }
+    
+    /**
+     * Parse version string into numeric parts.
+     */
+    private fun parseVersionParts(version: String): List<Int> {
+        val mainVersion = version.split("-")[0] // Remove pre-release suffix
+        return mainVersion.split(".").mapNotNull { it.toIntOrNull() }
+    }
+    
+    /**
+     * Extract pre-release information (type and number).
+     */
+    private fun extractPreReleaseInfo(version: String): Pair<String, Int>? {
+        val preReleaseRegex = Regex("-(alpha|beta|rc)_?(\\d+)?", RegexOption.IGNORE_CASE)
+        val match = preReleaseRegex.find(version) ?: return null
+        
+        val type = match.groupValues[1].lowercase()
+        val number = match.groupValues[2].toIntOrNull() ?: 1
+        
+        return Pair(type, number)
+    }
+    
+    /**
+     * Compare pre-release versions.
+     */
+    private fun comparePreReleases(preRelease1: Pair<String, Int>, preRelease2: Pair<String, Int>): Int {
+        val typeOrder = mapOf("alpha" to 1, "beta" to 2, "rc" to 3)
+        
+        val type1Order = typeOrder[preRelease1.first] ?: 0
+        val type2Order = typeOrder[preRelease2.first] ?: 0
+        
+        return when {
+            type1Order != type2Order -> type1Order.compareTo(type2Order)
+            else -> preRelease1.second.compareTo(preRelease2.second)
+        }
     }
 }

--- a/app/src/main/kotlin/de/cloudly/utils/SchedulerUtils.kt
+++ b/app/src/main/kotlin/de/cloudly/utils/SchedulerUtils.kt
@@ -1,0 +1,183 @@
+package de.cloudly.utils
+
+import org.bukkit.plugin.java.JavaPlugin
+import org.bukkit.scheduler.BukkitTask
+import java.lang.reflect.Method
+import java.util.concurrent.TimeUnit
+
+/**
+ * Utility class for cross-platform scheduling that works on both Paper and Folia.
+ * Automatically detects the server type and uses the appropriate scheduling method.
+ */
+object SchedulerUtils {
+    
+    private var isFolia: Boolean? = null
+    private var foliaGlobalRegionScheduler: Any? = null
+    private var foliaAsyncScheduler: Any? = null
+    private var foliaGlobalRegionSchedulerMethod: Method? = null
+    private var foliaAsyncSchedulerMethod: Method? = null
+    
+    /**
+     * Initialize the scheduler utility by detecting server type.
+     */
+    private fun initialize() {
+        if (isFolia != null) return
+        
+        try {
+            // Try to load Folia's GlobalRegionScheduler class
+            val foliaClass = Class.forName("io.papermc.paper.threadedregions.scheduler.GlobalRegionScheduler")
+            val asyncClass = Class.forName("io.papermc.paper.threadedregions.scheduler.AsyncScheduler")
+            val serverClass = Class.forName("org.bukkit.Bukkit")
+            
+            // Get Folia scheduler instances
+            foliaGlobalRegionSchedulerMethod = serverClass.getMethod("getGlobalRegionScheduler")
+            foliaAsyncSchedulerMethod = serverClass.getMethod("getAsyncScheduler")
+            
+            foliaGlobalRegionScheduler = foliaGlobalRegionSchedulerMethod?.invoke(null)
+            foliaAsyncScheduler = foliaAsyncSchedulerMethod?.invoke(null)
+            
+            isFolia = true
+            // Log successful Folia detection (optional, for debugging)
+        } catch (e: ClassNotFoundException) {
+            // Folia classes not found, we're on Paper/Spigot
+            isFolia = false
+        } catch (e: NoSuchMethodException) {
+            // Method not found, assume Paper/Spigot
+            isFolia = false
+        } catch (e: Exception) {
+            // Any other error, assume Paper/Spigot
+            isFolia = false
+        }
+    }
+    
+    /**
+     * Check if the server is running Folia.
+     */
+    fun isFolia(): Boolean {
+        initialize()
+        return isFolia ?: false
+    }
+    
+    /**
+     * Run a task on the main thread (global region in Folia).
+     */
+    fun runTask(plugin: JavaPlugin, task: Runnable): BukkitTask? {
+        initialize()
+        
+        return if (isFolia == true) {
+            try {
+                // Use Folia's global region scheduler
+                val runMethod = foliaGlobalRegionScheduler?.javaClass?.getMethod("run", JavaPlugin::class.java, Runnable::class.java)
+                runMethod?.invoke(foliaGlobalRegionScheduler, plugin, task)
+                null // Folia doesn't return BukkitTask
+            } catch (e: Exception) {
+                // Fallback to Bukkit scheduler - explicitly cast to Runnable
+                org.bukkit.Bukkit.getScheduler().runTask(plugin, task as Runnable)
+            }
+        } else {
+            // Use traditional Bukkit scheduler - explicitly cast to Runnable
+            org.bukkit.Bukkit.getScheduler().runTask(plugin, task as Runnable)
+        }
+    }
+    
+    /**
+     * Run a task asynchronously.
+     */
+    fun runTaskAsynchronously(plugin: JavaPlugin, task: Runnable): BukkitTask? {
+        initialize()
+        
+        return if (isFolia == true) {
+            try {
+                // Use Folia's async scheduler
+                val runNowMethod = foliaAsyncScheduler?.javaClass?.getMethod("runNow", JavaPlugin::class.java, Runnable::class.java)
+                runNowMethod?.invoke(foliaAsyncScheduler, plugin, task)
+                null // Folia doesn't return BukkitTask
+            } catch (e: Exception) {
+                // Fallback to Bukkit scheduler - explicitly cast to Runnable
+                org.bukkit.Bukkit.getScheduler().runTaskAsynchronously(plugin, task as Runnable)
+            }
+        } else {
+            // Use traditional Bukkit scheduler - explicitly cast to Runnable
+            org.bukkit.Bukkit.getScheduler().runTaskAsynchronously(plugin, task as Runnable)
+        }
+    }
+    
+    /**
+     * Run a repeating task asynchronously.
+     */
+    fun runTaskTimerAsynchronously(plugin: JavaPlugin, task: Runnable, delay: Long, period: Long): BukkitTask? {
+        initialize()
+        
+        return if (isFolia == true) {
+            try {
+                // Use Folia's async scheduler with repeating
+                val runAtFixedRateMethod = foliaAsyncScheduler?.javaClass?.getMethod(
+                    "runAtFixedRate", 
+                    JavaPlugin::class.java, 
+                    Runnable::class.java, 
+                    Long::class.javaPrimitiveType, 
+                    Long::class.javaPrimitiveType, 
+                    TimeUnit::class.java
+                )
+                
+                // Convert ticks to milliseconds (20 ticks = 1 second = 1000ms)
+                val delayMs = delay * 50L
+                val periodMs = period * 50L
+                
+                runAtFixedRateMethod?.invoke(
+                    foliaAsyncScheduler, 
+                    plugin, 
+                    task, 
+                    delayMs, 
+                    periodMs, 
+                    TimeUnit.MILLISECONDS
+                )
+                null // Folia doesn't return BukkitTask
+            } catch (e: Exception) {
+                // Fallback to Bukkit scheduler - explicitly cast to Runnable
+                org.bukkit.Bukkit.getScheduler().runTaskTimerAsynchronously(plugin, task as Runnable, delay, period)
+            }
+        } else {
+            // Use traditional Bukkit scheduler - explicitly cast to Runnable
+            org.bukkit.Bukkit.getScheduler().runTaskTimerAsynchronously(plugin, task as Runnable, delay, period)
+        }
+    }
+    
+    /**
+     * Schedule a delayed task asynchronously.
+     */
+    fun runTaskLaterAsynchronously(plugin: JavaPlugin, task: Runnable, delay: Long): BukkitTask? {
+        initialize()
+        
+        return if (isFolia == true) {
+            try {
+                // Use Folia's async scheduler with delay
+                val runDelayedMethod = foliaAsyncScheduler?.javaClass?.getMethod(
+                    "runDelayed", 
+                    JavaPlugin::class.java, 
+                    Runnable::class.java, 
+                    Long::class.javaPrimitiveType, 
+                    TimeUnit::class.java
+                )
+                
+                // Convert ticks to milliseconds (20 ticks = 1 second = 1000ms)
+                val delayMs = delay * 50L
+                
+                runDelayedMethod?.invoke(
+                    foliaAsyncScheduler, 
+                    plugin, 
+                    task, 
+                    delayMs, 
+                    TimeUnit.MILLISECONDS
+                )
+                null // Folia doesn't return BukkitTask
+            } catch (e: Exception) {
+                // Fallback to Bukkit scheduler - explicitly cast to Runnable
+                org.bukkit.Bukkit.getScheduler().runTaskLaterAsynchronously(plugin, task as Runnable, delay)
+            }
+        } else {
+            // Use traditional Bukkit scheduler - explicitly cast to Runnable
+            org.bukkit.Bukkit.getScheduler().runTaskLaterAsynchronously(plugin, task as Runnable, delay)
+        }
+    }
+}

--- a/app/src/main/resources/lang/de.yml
+++ b/app/src/main/resources/lang/de.yml
@@ -2,9 +2,11 @@
 
 # Plugin messages
 plugin:
-  enabled: "Cloudly Plugin v{version} auf Paper aktiviert!"
+  enabled: "Cloudly Plugin v{version} auf Paper/Folia aktiviert!"
   disabled: "Cloudly Plugin deaktiviert"
   debug_enabled: "Debug-Modus ist aktiviert"
+  folia_detected: "Folia-Server erkannt - verwende Folia-Scheduler"
+  paper_detected: "Paper/Spigot-Server erkannt - verwende Bukkit-Scheduler"
 
 # Configuration messages
 config:

--- a/app/src/main/resources/lang/en.yml
+++ b/app/src/main/resources/lang/en.yml
@@ -2,9 +2,11 @@
 
 # Plugin messages
 plugin:
-  enabled: "Cloudly Plugin v{version} enabled on Paper!"
+  enabled: "Cloudly Plugin v{version} enabled on Paper/Folia!"
   disabled: "Cloudly Plugin disabled"
   debug_enabled: "Debug mode is enabled"
+  folia_detected: "Folia server detected - using Folia schedulers"
+  paper_detected: "Paper/Spigot server detected - using Bukkit schedulers"
 
 # Configuration messages
 config:

--- a/app/src/main/resources/plugin.yml
+++ b/app/src/main/resources/plugin.yml
@@ -2,9 +2,10 @@ name: Cloudly
 version: ${version}
 main: de.cloudly.CloudlyPaper
 author: Phantom
-description: A simple plugin to manage a Paper server.
+description: A simple plugin to manage a Paper server with Folia support.
 api-version: 1.20
 load: STARTUP
+folia-supported: true
 
 permissions:
   cloudly.admin:

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
 }
 
 group = "de.cloudly"
-version = "1.0.0-alpha_4"
+version = "1.0.0-alpha_5"
 
 repositories {
     mavenCentral()

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -20,6 +20,9 @@ repositories {
 dependencies {
     // Paper API for 1.20+
     compileOnly("io.papermc.paper:paper-api:1.20.1-R0.1-SNAPSHOT")
+    
+    // Folia API for Folia support
+    compileOnly("dev.folia:folia-api:1.20.1-R0.1-SNAPSHOT")
 
     implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8")
     


### PR DESCRIPTION
Introduce support for Folia alongside Paper servers, update documentation, and improve version comparison logic to handle semantic versioning and pre-release identifiers. Enhance logging for server type detection and refactor code for better performance. Bump version to 1.0.0-alpha_5.